### PR TITLE
Separate build.yml into pr.yml and push.yml ++ Badges

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,6 @@
-name: Primaza Build
+name: Primaza Pull Request Build
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -12,8 +10,6 @@ jobs:
     strategy:
       matrix:
         java: [
-          { 'version': '11', opts: '' },
-          { 'version': '16', 'opts': '' },
           { 'version': '17', 'opts': '' }
         ]
     name: build with jdk ${{matrix.java.version}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,32 @@
+name: Primaza Push Build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [
+          { 'version': '11', opts: '' },
+          { 'version': '16', 'opts': '' },
+          { 'version': '17', 'opts': '' }
+        ]
+    name: build with jdk ${{matrix.java.version}}
+
+    steps:
+      - uses: actions/checkout@v2
+        name: checkout
+
+      - uses: actions/setup-java@v2
+        name: set up jdk ${{matrix.java.version}}
+        with:
+          distribution: temurin
+          java-version: ${{matrix.java.version}}
+          cache: maven
+
+      - name: build with maven
+        run: mvn clean install
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<p align="center">
+    <a href="https://github.com/halkyonio/primaza-poc/graphs/contributors" alt="Contributors">
+        <img src="https://img.shields.io/github/contributors/halkyonio/primaza-poc"/></a>
+    <a href="https://github.com/halkyonio/primaza-poc/pulse" alt="Activity">
+        <img src="https://img.shields.io/github/commit-activity/m/halkyonio/primaza-poc"/></a>
+    <a href="https://github.com/halkyonio/primaza-poc/actions/workflows/push.yml" alt="Build Status">
+        <img src="https://github.com/halkyonio/primaza-poc/actions/workflows/push.yaml/badge.svg"></a>
+</p>
+
 # Primaza project
 
 Quarkus Primaza Service box Application - POC


### PR DESCRIPTION
By having the build.yml into two files, we can run different actions in pull requests and when pushing to main. This way we can add many more things (for example: coverage in OpenShift) in the push.yml to verify everything works as expected without having pull requests to wait all these actions to finish. 

Moreover, this is necessary to having a badge to see the health status of the project because there will be only one push action at a time, when it could be many pull requests actions (the badge will pick the latest one of a pull request that is not merged yet). 

Fix https://github.com/halkyonio/primaza-poc/issues/19