### PR TITLE
Replace Quarkus Container Image Jib by Quarkus Container Image Docker

### DIFF
--- a/servicebox-app/pom.xml
+++ b/servicebox-app/pom.xml
@@ -170,7 +170,7 @@
       <dependencies>
         <dependency>
           <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-container-image-jib</artifactId>
+          <artifactId>quarkus-container-image-docker</artifactId>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
This is necessary because the base image that uses Jib does not have some tools like tar.  On the other hand, the base image that uses Docker does.