### PR TITLE
Revert pe

### DIFF
--- a/scripts/primaza.sh
+++ b/scripts/primaza.sh
@@ -17,17 +17,11 @@ IMAGE_VERSION=latest
 INGRESS_HOST=primaza.${VM_IP}.nip.io
 PROJECT_NAME=primaza-poc
 PROJECT_DIR=servicebox-app
-CLONING_PRIMAZA=${CLONING_PRIMAZA:=false}
 GITHUB_REPO_PRIMAZA=https://github.com/halkyonio/primaza-poc.git
 
 # Parameters to play the demo
 TYPE_SPEED=${TYPE_SPEED:=40}
 NO_WAIT=true
-
-if [ "${CLONING_PRIMAZA}" = true ]; then
-  pe "rm -rf ${PROJECT_NAME}"
-  pe "git clone ${GITHUB_REPO_PRIMAZA} && cd ${PROJECT_NAME}"
-fi
 
 pushd ${PROJECT_DIR}
 

--- a/scripts/primaza.sh
+++ b/scripts/primaza.sh
@@ -66,7 +66,7 @@ done
 
 p "Get the kubeconf and creating a cluster"
 KIND_URL=https://kubernetes.default.svc
-kind get kubeconfig > local-kind-kubeconfig
+pe "kind get kubeconfig > local-kind-kubeconfig"
 pe "k cp local-kind-kubeconfig ${NAMESPACE}/${POD_NAME:4}:/tmp/local-kind-kubeconfig -c servicebox-app"
 
 RESULT=$(k exec -i $POD_NAME -c servicebox-app -n ${NAMESPACE} -- sh -c "curl -X POST -H 'Content-Type: multipart/form-data' -H 'HX-Request: true' -F name=local-kind -F environment=DEV -F url=$KIND_URL -F kubeConfig=@/tmp/local-kind-kubeconfig -s -i localhost:8080/clusters")

--- a/scripts/primaza.sh
+++ b/scripts/primaza.sh
@@ -73,10 +73,10 @@ RESULT=$(k exec -i $POD_NAME -c servicebox-app -n ${NAMESPACE} -- sh -c "curl -X
 if [ "$RESULT" = *"500 Internal Server Error"* ]
 then
     p "Cluster failed to be saved in Service Box: $RESULT"
-    pe "k describe $POD_NAME -n ${NAMESPACE}"
-    pe "k logs $POD_NAME -n ${NAMESPACE}"
+    k describe $POD_NAME -n ${NAMESPACE}
+    k logs $POD_NAME -n ${NAMESPACE}
     exit 1
 fi
-p "Local k8s cluster registered: $RESULT"
+note "Local k8s cluster registered: $RESULT"
 
 popd

--- a/scripts/primaza.sh
+++ b/scripts/primaza.sh
@@ -34,7 +34,7 @@ pushd ${PROJECT_DIR}
 p "SCRIPTS_DIR dir: ${SCRIPTS_DIR}"
 p "Ingress host is: ${INGRESS_HOST}"
 
-curl -s -L https://raw.githubusercontent.com/snowdrop/k8s-infra/main/kind/kind-reg-ingress.sh | bash -s y latest 0
+pe "curl -s -L https://raw.githubusercontent.com/snowdrop/k8s-infra/main/kind/kind-reg-ingress.sh | bash -s y latest 0"
 pe "k wait -n ingress \
   --for=condition=ready pod \
   --selector=app.kubernetes.io/component=controller \


### PR DESCRIPTION
- Revert pe function as this command `bash <(curl -s -L https://raw.githubusercontent.com/halkyonio/primaza-poc/main/scripts/install.sh) 65.108.212.158` do not generate anymore the `stty: standard input: Inappropriate ioctl for device`
- Clean some pe calls when not needed
- Remove commands to git/clone primaza project