### PR TITLE
make volume mounting idempotent

### DIFF
--- a/app/src/main/java/io/halkyon/services/KubernetesClientService.java
+++ b/app/src/main/java/io/halkyon/services/KubernetesClientService.java
@@ -135,6 +135,7 @@ public class KubernetesClientService {
          * Mount the secret
          */
         Deployment newDeployment = new DeploymentBuilder(deployment).accept(ContainerBuilder.class, container -> {
+            container.removeMatchingFromVolumeMounts(vm -> Objects.equals(secretName,vm.getName()) && Objects.equals(SERVICE_BINDING_ROOT_DEFAULT_VALUE + "/" + secretName, vm.getMountPath()));
             container.addNewVolumeMount().withName(secretName)
                     .withMountPath(SERVICE_BINDING_ROOT_DEFAULT_VALUE + "/" + secretName).endVolumeMount();
             container.removeMatchingFromEnv(e -> Objects.equals(SERVICE_BINDING_ROOT, e.getName()));

--- a/app/src/main/java/io/halkyon/services/KubernetesClientService.java
+++ b/app/src/main/java/io/halkyon/services/KubernetesClientService.java
@@ -135,7 +135,8 @@ public class KubernetesClientService {
          * Mount the secret
          */
         Deployment newDeployment = new DeploymentBuilder(deployment).accept(ContainerBuilder.class, container -> {
-            container.removeMatchingFromVolumeMounts(vm -> Objects.equals(secretName,vm.getName()) && Objects.equals(SERVICE_BINDING_ROOT_DEFAULT_VALUE + "/" + secretName, vm.getMountPath()));
+            container.removeMatchingFromVolumeMounts(vm -> Objects.equals(secretName, vm.getName())
+                    && Objects.equals(SERVICE_BINDING_ROOT_DEFAULT_VALUE + "/" + secretName, vm.getMountPath()));
             container.addNewVolumeMount().withName(secretName)
                     .withMountPath(SERVICE_BINDING_ROOT_DEFAULT_VALUE + "/" + secretName).endVolumeMount();
             container.removeMatchingFromEnv(e -> Objects.equals(SERVICE_BINDING_ROOT, e.getName()));


### PR DESCRIPTION
When volume path exists in the container we get a `Message: Deployment.apps "atomic-fruits" is invalid .... volume path must be unique`.
Fixes #248 