### PR TITLE
Not deleting the cluster when a linked application is deleted

### DIFF
--- a/app/src/main/java/io/halkyon/model/Application.java
+++ b/app/src/main/java/io/halkyon/model/Application.java
@@ -1,6 +1,6 @@
 package io.halkyon.model;
 
-import static javax.persistence.CascadeType.ALL;
+import static javax.persistence.CascadeType.PERSIST;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -16,7 +16,7 @@ public class Application extends PanacheEntity {
     public String namespace;
     public String image;
 
-    @ManyToOne(cascade = ALL, fetch = FetchType.EAGER)
+    @ManyToOne(cascade = PERSIST, fetch = FetchType.EAGER)
     @JoinColumn(name = "cluster_id")
     public Cluster cluster;
 


### PR DESCRIPTION
Using CASCADE=ALL makes the child entity (the cluster) to be deleted, when the parent entity (the application) is deleted. 

Fix https://github.com/halkyonio/primaza-poc/issues/258