### PR TITLE
Configure quarkus vault extension properly

### DIFF
--- a/app/src/main/java/io/halkyon/resource/GreetingResource.java
+++ b/app/src/main/java/io/halkyon/resource/GreetingResource.java
@@ -11,9 +11,6 @@ import io.quarkus.vault.VaultKVSecretEngine;
 
 @Path("/hello")
 public class GreetingResource {
-    //
-    // @ConfigProperty(name = "a-private-key")
-    // String privateKey;
 
     @Inject
     VaultKVSecretEngine kvSecretEngine;
@@ -22,13 +19,7 @@ public class GreetingResource {
     @Path("/secrets/{vault-path}")
     @Produces(MediaType.TEXT_PLAIN)
     public String getSecrets(@PathParam("vault-path") String vaultPath) {
-        return kvSecretEngine.readSecret("myapps/vault-quickstart/" + vaultPath).toString();
+        return kvSecretEngine.readSecret("primaza/" + vaultPath).toString();
     }
 
-    // @GET
-    // @Path("/private-key")
-    // @Produces(MediaType.TEXT_PLAIN)
-    // public String privateKey() {
-    // return privateKey;
-    // }
 }

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -16,6 +16,5 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 
-%prod.quarkus.vault.kv-secret-engine-version=1
-%prod.quarkus.vault.kv-secret-engine-mount-path=kv
+%prod.quarkus.vault.kv-secret-engine-mount-path=kv2
 

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -9,11 +9,13 @@ quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 # vault url
-%prod.quarkus.vault.url=http://localhost:8200
+%prod.quarkus.vault.url=http://vault.65.108.212.158.nip.io
+%dev.quarkus.vault.url=http://vault.127.0.0.1.nip.io
 
 # vault authentication
-%prod.quarkus.vault.authentication.userpass.username=bob
-%prod.quarkus.vault.authentication.userpass.password=sinclair
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password=sinclair
+quarkus.log.category."io.quarkus.vault".level=DEBUG
+quarkus.vault.kv-secret-engine-version=1
+quarkus.vault.kv-secret-engine-mount-path=kv
 
-# path within the kv secret engine where is located the vault-quickstart secret configuration
-%prod.quarkus.vault.secret-config-kv-path=myapps/vault-quickstart/config

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -15,7 +15,7 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # vault authentication
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
-quarkus.log.category."io.quarkus.vault".level=DEBUG
-quarkus.vault.kv-secret-engine-version=1
-quarkus.vault.kv-secret-engine-mount-path=kv
+
+%prod.quarkus.vault.kv-secret-engine-version=1
+%prod.quarkus.vault.kv-secret-engine-mount-path=kv
 

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -180,7 +180,7 @@ function registerUser() {
   fi
 
   log BLUE "Creating a new vault user: ${VAULT_USER}, password: ${VAULT_PASSWORD} having as policy: ${VAULT_POLICY_NAME}"
-  #vaultExec "vault write auth/userpass/users/${VAULT_USER} password=${VAULT_PASSWORD} policies=${VAULT_POLICY_NAME}"
+  vaultExec "vault write auth/userpass/users/${VAULT_USER} password=${VAULT_PASSWORD} policies=${VAULT_POLICY_NAME}"
 }
 
 case $1 in
@@ -210,7 +210,6 @@ createTokensKubernetesSecret
 createUserPolicy
 registerUser
 loginAsUser
-vaultExec "vault kv put kv/primaza/hello target=world"
 
 log YELLOW "Temporary folder containing created files: ${TMP_DIR}"
 log YELLOW "Vault Root Token: $(jq -r ".root_token" ${TMP_DIR}/cluster-keys.json)"


### PR DESCRIPTION
By default Quarkus assumes that a kv secret engine in version 2 mounted at path secret/ will be used. This is not the case for us so we need to use properties quarkus.vault.kv-secret-engine-version and quarkus.vault.kv-secret-engine-mount-path accordingly.

[We should review the script to set up kv secret engine version 2 and the mount path](https://github.com/halkyonio/primaza-poc/issues/265) ???

Fixes #262