### PR TITLE
Push images with version "latest", upgrade Quarkus Helm to 0.2.7

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -248,4 +248,4 @@ jobs:
         run: docker login quay.io -u="${{secrets.QUAY_USER}}" -p="${{secrets.QUAY_TOKEN}}"
 
       - name: Push
-        run: mvn clean install -DskipTests -Ppush-images -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=quay.io -Dquarkus.container-image.group=halkyonio
+        run: mvn clean install -DskipTests -Ppush-images -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=quay.io -Dquarkus.container-image.group=halkyonio -Dquarkus.container-image.tag=latest

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -15,7 +15,7 @@
     <bootstrap-icons.version>1.7.0</bootstrap-icons.version>
     <bootstrap.version>5.2.2</bootstrap.version>
     <htmx.version>1.8.2</htmx.version>
-    <quarkus-helm.version>0.2.5</quarkus-helm.version>
+    <quarkus-helm.version>0.2.7</quarkus-helm.version>
   </properties>
   <dependencies>
     <dependency>

--- a/app/src/main/resources/application-kubernetes.properties
+++ b/app/src/main/resources/application-kubernetes.properties
@@ -2,6 +2,8 @@ primaza.update-claim-job.max-attempts=3
 primaza.update-claim-job.poll-every=5m
 primaza.discovery-service-job.poll-every=10s
 
+database.service.name=${DB_SERVICE_NAME:primaza-app-db}
+
 # Database Configuration
 quarkus.datasource.db-kind=postgresql
 ## TODO: to be deleted in https://github.com/halkyonio/primaza-poc/issues/62
@@ -15,7 +17,7 @@ quarkus.kubernetes.env.vars.GITHUB_REPO=${github.repo}
 quarkus.kubernetes.env.vars.GIT_SHA_COMMIT=${git.sha.commit}
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_USERNAME=user
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_PASSWORD=pwd
-quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://primaza-app-db:5432/primaza_database
+quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://${database.service.name}:5432/primaza_database
 
 # Helm Configuration
 quarkus.helm.name=primaza-app
@@ -23,7 +25,7 @@ quarkus.helm.dependencies.0.alias=db
 quarkus.helm.dependencies.0.name=postgresql
 quarkus.helm.dependencies.0.version=11.9.1
 quarkus.helm.dependencies.0.repository=https://charts.bitnami.com/bitnami
-quarkus.helm.dependencies.0.wait-for-service=primaza-app-db:5432
+quarkus.helm.dependencies.0.wait-for-service=${database.service.name}:5432
 
 quarkus.helm.values.0.property=db.auth.database
 quarkus.helm.values.0.value=primaza_database


### PR DESCRIPTION
These changes will:
- Push images with version "latest" into the quay.io account.
- Upgrade Quarkus Helm to 0.2.7 that will automatically map environment properties, which will allow to configure the postgresql service name when installing the Helm chart.