### PR TITLE
issue-278

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         java: [
-          { 'version': '11', opts: '' },
-          { 'version': '16', 'opts': '' },
           { 'version': '17', 'opts': '' }
         ]
     name: build with jdk ${{matrix.java.version}}


### PR DESCRIPTION
- Remove non needed java versions from github action flow. jdk 17 is enough
- Fix #278