### PR TITLE
Use autoconfigure to allow read configuration from properties

### DIFF
--- a/app/src/main/java/io/halkyon/services/KubernetesClientService.java
+++ b/app/src/main/java/io/halkyon/services/KubernetesClientService.java
@@ -188,7 +188,7 @@ public class KubernetesClientService {
             if (StringUtils.isNotEmpty(cluster.kubeConfig)) {
                 config = Config.fromKubeconfig(cluster.kubeConfig);
             } else {
-                config = Config.empty();
+                config = Config.autoConfigure(null);
             }
 
             config.setMasterUrl(cluster.url);


### PR DESCRIPTION
Using this because `Config.empty()` doesn't allow any automatic configuration