### PR TITLE
Remove build on native

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,29 +28,6 @@ jobs:
       - name: build with maven
         run: mvn clean install -Pvalidate-format
 
-  build-native:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [
-          { 'version': '11', opts: '' }
-        ]
-    name: build with native
-
-    steps:
-      - uses: actions/checkout@v2
-        name: checkout
-
-      - uses: actions/setup-java@v2
-        name: set up jdk ${{matrix.java.version}}
-        with:
-          distribution: temurin
-          java-version: ${{matrix.java.version}}
-          cache: maven
-
-      - name: build with maven
-        run: mvn clean install -Dnative -Dquarkus.test.native-image-profile=test
-
   verify-in-kubernetes:
     name: Verify in Kubernetes
     runs-on: ubuntu-latest

--- a/app/src/test/java/io/halkyon/ClaimsEndpointIT.java
+++ b/app/src/test/java/io/halkyon/ClaimsEndpointIT.java
@@ -1,7 +1,0 @@
-package io.halkyon;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest
-public class ClaimsEndpointIT extends ClaimsEndpointTest {
-}

--- a/app/src/test/java/io/halkyon/ClustersEndpointIT.java
+++ b/app/src/test/java/io/halkyon/ClustersEndpointIT.java
@@ -1,7 +1,0 @@
-package io.halkyon;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest
-public class ClustersEndpointIT extends ClustersEndpointTest {
-}

--- a/app/src/test/java/io/halkyon/ClustersEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ClustersEndpointTest.java
@@ -4,7 +4,6 @@ import static io.halkyon.utils.TestUtils.createCluster;
 import static io.halkyon.utils.TestUtils.createService;
 import static io.halkyon.utils.TestUtils.mockServiceIsAvailableInCluster;
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.core.IsNot.not;
 
 import jakarta.ws.rs.core.MediaType;
 
@@ -14,7 +13,6 @@ import io.halkyon.model.Cluster;
 import io.halkyon.services.KubernetesClientService;
 import io.halkyon.utils.WebPageExtension;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 
@@ -60,12 +58,7 @@ public class ClustersEndpointTest {
         page.assertContentContains(cluster.name + "-new");
     }
 
-    /**
-     * `@InjectMock` does not work when running tests in prod mode.
-     */
-    @DisabledOnIntegrationTest
     @Test
-    // @Disabled
     public void testDeleteClusterInPage() {
         // First, we create a cluster with a service
         String prefix = "ClustersEndpointTest-testDeleteClusterInPage-";

--- a/app/src/test/java/io/halkyon/CredentialsPageIT.java
+++ b/app/src/test/java/io/halkyon/CredentialsPageIT.java
@@ -1,8 +1,0 @@
-package io.halkyon;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest
-public class CredentialsPageIT extends CredentialsPageTest {
-    // Execute the same tests but in packaged mode.
-}

--- a/app/src/test/java/io/halkyon/HomeResourceIT.java
+++ b/app/src/test/java/io/halkyon/HomeResourceIT.java
@@ -1,8 +1,0 @@
-package io.halkyon;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest
-public class HomeResourceIT extends HomeResourceTest {
-    // Execute the same tests but in packaged mode.
-}

--- a/app/src/test/java/io/halkyon/ServicesEndpointIT.java
+++ b/app/src/test/java/io/halkyon/ServicesEndpointIT.java
@@ -1,8 +1,0 @@
-package io.halkyon;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest
-public class ServicesEndpointIT extends ServicesEndpointTest {
-
-}

--- a/app/src/test/java/io/halkyon/ServicesEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ServicesEndpointTest.java
@@ -16,7 +16,6 @@ import io.halkyon.model.Service;
 import io.halkyon.services.KubernetesClientService;
 import io.halkyon.utils.WebPageExtension;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 
@@ -68,7 +67,6 @@ public class ServicesEndpointTest {
                 .put("/services/" + service2.id).then().statusCode(409);
     }
 
-    @DisabledOnIntegrationTest
     @Test
     public void testEditServiceFromPage() {
         // Create data
@@ -134,10 +132,6 @@ public class ServicesEndpointTest {
         // page.assertContentContains("rabbit.com");
     }
 
-    /**
-     * `@InjectMock` does not work when running tests in prod mode.
-     */
-    @DisabledOnIntegrationTest
     @Test
     public void testDeleteServiceWithClusterInPage() {
         // First, we create a cluster with a service


### PR DESCRIPTION
This is taking much time to build after pushing commits on main. Plus, we're not using the native tests and some tests were failing because it uses `@InjectMock` which is not compatible with running tests on Native.