### PR TITLE
Disable logs for WebMockServer and HTMLUnit

### DIFF
--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.log.category."okhttp3.mockwebserver".level=WARN
+quarkus.log.category."com.gargoylesoftware.htmlunit".level=OFF


### PR DESCRIPTION
These logs were not helpful and sometimes misleading as HTMLUnit traces an error message when something is not found (spites it's expected not to be found).