### PR TITLE
Remove HX-Request header usage in tests and scripts

### DIFF
--- a/.github/bind_application_to_claim_in_primaza.sh
+++ b/.github/bind_application_to_claim_in_primaza.sh
@@ -14,7 +14,7 @@ CLAIM=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES
 CLAIM_ID=$(echo "$CLAIM" | jq -r '.id')
 echo "Claim ID to be bound $CLAIM_ID"
 
-RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' -H 'HX-Request: true' -d 'claimId=$CLAIM_ID' -s -i localhost:8080/applications/claim/$APPLICATION_ID")
+RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' -d 'claimId=$CLAIM_ID' -s -i localhost:8080/applications/claim/$APPLICATION_ID")
 if [[ "$RESULT" = *"500 Internal Server Error"* ]]
 then
   echo "Application failed to be bound in Primaza: $RESULT"

--- a/.github/register_claim_in_primaza.sh
+++ b/.github/register_claim_in_primaza.sh
@@ -6,7 +6,7 @@ PRIMAZA_KUBERNETES_NAMESPACE=sb
 POD_NAME=$(kubectl get pod -l app.kubernetes.io/name=primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -o name)
 
 PARAMS="name=$CLAIM_NAME&serviceRequested=$CLAIM_REQUESTED_SERVICE"
-RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' -H 'HX-Request: true' -d '$PARAMS' -s -i localhost:8080/claims")
+RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' -d '$PARAMS' -s -i localhost:8080/claims")
 if [[ "$RESULT" = *"500 Internal Server Error"* ]]
 then
   echo "Claim failed to be saved in Primaza: $RESULT"

--- a/.github/register_local_kind_cluster_in_primaza.sh
+++ b/.github/register_local_kind_cluster_in_primaza.sh
@@ -9,7 +9,7 @@ POD_NAME=$(kubectl get pod -l app.kubernetes.io/name=primaza-app -n $PRIMAZA_KUB
 # KIND_URL=$(kubectl config view -o jsonpath='{"Cluster name\tServer\n"}{range .clusters[*]}{.name}{"\t"}{.cluster.server}{"\n"}{end}' | grep kind-kind | sed "s/kind-kind//" | xargs)
 kind get kubeconfig > /tmp/local-kind-kubeconfig
 kubectl cp /tmp/local-kind-kubeconfig sb/${POD_NAME:4}:/tmp/local-kind-kubeconfig -c primaza-app
-RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: multipart/form-data' -H 'HX-Request: true' -F name=local-kind -F excludedNamespaces=$EXCLUDED_NAMESPACES -F environment=DEV -F url=$KIND_URL -F kubeConfig=@/tmp/local-kind-kubeconfig -s -i localhost:8080/clusters")
+RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: multipart/form-data' -F name=local-kind -F excludedNamespaces=$EXCLUDED_NAMESPACES -F environment=DEV -F url=$KIND_URL -F kubeConfig=@/tmp/local-kind-kubeconfig -s -i localhost:8080/clusters")
 if [[ "$RESULT" = *"500 Internal Server Error"* ]]
 then
   echo "Cluster failed to be saved in Primaza: $RESULT"

--- a/.github/register_service_credential_in_primaza.sh
+++ b/.github/register_service_credential_in_primaza.sh
@@ -14,7 +14,7 @@ SERVICE_ID=$(echo "$SERVICE" | jq -r '.id')
 
 BODY="name=$CREDENTIAL_NAME&serviceId=$SERVICE_ID&username=$USERNAME&password=$PASSWORD&params=database:$DATABASE_NAME"
 echo "Sending service credential with body: $BODY"
-RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' -H 'HX-Request: true' -d '$BODY' -s -i localhost:8080/credentials")
+RESULT=$(kubectl exec -i $POD_NAME --container primaza-app -n $PRIMAZA_KUBERNETES_NAMESPACE -- sh -c "curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' -d '$BODY' -s -i localhost:8080/credentials")
 if [[ "$RESULT" = *"500 Internal Server Error"* ]]
 then
   echo "Credential failed to be saved in Primaza: $RESULT"

--- a/app/src/main/java/io/halkyon/resource/page/ClaimResource.java
+++ b/app/src/main/java/io/halkyon/resource/page/ClaimResource.java
@@ -13,7 +13,6 @@ import jakarta.validation.Validator;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -118,7 +117,7 @@ public class ClaimResource {
     @Transactional
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.TEXT_HTML)
-    public Response add(@Form ClaimRequest claimRequest, @HeaderParam("HX-Request") boolean hxRequest) {
+    public Response add(@Form ClaimRequest claimRequest) {
         Set<ConstraintViolation<ClaimRequest>> errors = validator.validate(claimRequest);
         AcceptedResponseBuilder response = AcceptedResponseBuilder.withLocation("/claims");
 

--- a/app/src/main/java/io/halkyon/resource/page/CredentialResource.java
+++ b/app/src/main/java/io/halkyon/resource/page/CredentialResource.java
@@ -11,7 +11,6 @@ import jakarta.validation.Validator;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -51,7 +50,7 @@ public class CredentialResource {
     @Transactional
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.TEXT_HTML)
-    public Response add(@Form CredentialRequest request, @HeaderParam("HX-Request") boolean hxRequest) {
+    public Response add(@Form CredentialRequest request) {
         Set<ConstraintViolation<CredentialRequest>> errors = validator.validate(request);
         AcceptedResponseBuilder response = AcceptedResponseBuilder.withLocation("/credentials");
         if (!errors.isEmpty()) {

--- a/app/src/main/java/io/halkyon/resource/page/ServiceResource.java
+++ b/app/src/main/java/io/halkyon/resource/page/ServiceResource.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -61,7 +60,7 @@ public class ServiceResource {
     @Transactional
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.TEXT_HTML)
-    public Response add(@Form ServiceRequest request, @HeaderParam("HX-Request") boolean hxRequest) {
+    public Response add(@Form ServiceRequest request) {
         Set<ConstraintViolation<ServiceRequest>> errors = validator.validate(request);
         AcceptedResponseBuilder response = AcceptedResponseBuilder.withLocation("/services");
 

--- a/app/src/test/java/io/halkyon/ClaimServiceTest.java
+++ b/app/src/test/java/io/halkyon/ClaimServiceTest.java
@@ -115,9 +115,9 @@ public class ClaimServiceTest {
     @Test
     public void testShouldClaimServiceWhenNewClaimIsCreated() {
         pauseScheduler();
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", "Oracle1").formParam("serviceRequested", "oracle-1234")
-                .formParam("description", "Description").when().post("/claims").then().statusCode(201);
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", "Oracle1")
+                .formParam("serviceRequested", "oracle-1234").formParam("description", "Description").when()
+                .post("/claims").then().statusCode(201);
         given().contentType(MediaType.APPLICATION_JSON).get("/claims/name/Oracle1").then().statusCode(200)
                 .body("status", is(ClaimStatus.PENDING.toString())).body("attempts", is(1));
     }

--- a/app/src/test/java/io/halkyon/ClaimsEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ClaimsEndpointTest.java
@@ -29,8 +29,7 @@ public class ClaimsEndpointTest {
 
     @Test
     public void testQueryClaimBody() {
-        RequestSpecification httpRequest = RestAssured.given().header("HX-Request", "true").queryParam("name",
-                "mysql-demo");
+        RequestSpecification httpRequest = RestAssured.given().queryParam("name", "mysql-demo");
         Response response = httpRequest.get("/claims/filter");
         ResponseBody body = response.getBody();
         MatcherAssert.assertThat(body, Matchers.notNullValue());
@@ -40,7 +39,7 @@ public class ClaimsEndpointTest {
     public void testQueryUsingNameToGetClaims() {
         final String claimName = "testQueryUsingNameToGetClaims";
         createClaim(claimName, "Postgresql-5509");
-        given().header("HX-Request", "true").queryParam("name", claimName).when().get("/claims/filter").then()
+        given().queryParam("name", claimName).when().get("/claims/filter").then()
                 .body(containsString("<td>" + claimName + "</td>"));
     }
 
@@ -48,16 +47,15 @@ public class ClaimsEndpointTest {
     public void testQueryUsingServiceRequestedToGetClaims() {
         final String claimName = "testQueryUsingServiceRequestedToGetClaims";
         createClaim(claimName, "Postgresql-5509");
-        given().header("HX-Request", "true").queryParam("servicerequested", "Postgresql-5509").when()
-                .get("/claims/filter").then().body(containsString("<td>" + claimName + "</td>"));
+        given().queryParam("servicerequested", "Postgresql-5509").when().get("/claims/filter").then()
+                .body(containsString("<td>" + claimName + "</td>"));
     }
 
     @Test
     public void claimCreatedViaForm() {
-        // An htmx request will contain a HX-Request header and Content-Type: application/x-www-form-urlencoded
         String claimName = "mysql-claim";
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", claimName).formParam("serviceRequested", "mysql-8.0.3")
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", claimName)
+                .formParam("serviceRequested", "mysql-8.0.3")
                 .formParam("description", "mysql claim for testing purposes").when().post("/claims").then()
                 .statusCode(201);
 
@@ -77,8 +75,8 @@ public class ClaimsEndpointTest {
         given().contentType(MediaType.APPLICATION_JSON).get("/claims/name/" + claimName).then().statusCode(200)
                 .extract().as(Claim.class);
 
-        given().header("HX-Request", "true").contentType(MediaType.APPLICATION_FORM_URLENCODED).when()
-                .delete("/claims/" + claim.id).then().statusCode(200);
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).when().delete("/claims/" + claim.id).then()
+                .statusCode(200);
     }
 
     @Test

--- a/app/src/test/java/io/halkyon/ClustersEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ClustersEndpointTest.java
@@ -28,11 +28,9 @@ public class ClustersEndpointTest {
     @Test
     // @Disabled
     public void testAddClusterViaHtmxForm() {
-        // A htmx request will contain a HX-Request header and Content-Type: application/x-www-form-urlencoded
-        given().header("HX-Request", true).contentType(MediaType.MULTIPART_FORM_DATA)
-                .multiPart("name", "ocp4.11-node-2").multiPart("environment", "TEST")
-                .multiPart("excludedNamespaces", "kube-system,ingress").multiPart("url", "https://10.0.2.12:6443")
-                .when().post("/clusters").then().statusCode(201);
+        given().contentType(MediaType.MULTIPART_FORM_DATA).multiPart("name", "ocp4.11-node-2")
+                .multiPart("environment", "TEST").multiPart("excludedNamespaces", "kube-system,ingress")
+                .multiPart("url", "https://10.0.2.12:6443").when().post("/clusters").then().statusCode(201);
     }
 
     @Test

--- a/app/src/test/java/io/halkyon/ServiceDiscoveryJobTest.java
+++ b/app/src/test/java/io/halkyon/ServiceDiscoveryJobTest.java
@@ -77,9 +77,9 @@ public class ServiceDiscoveryJobTest {
         String serviceName = "ServiceDiscoveryJobTest2";
         Cluster cluster = createCluster("dummy-cluster-2", "master:port");
         configureMockServiceFor(cluster.name, "host", "2222", "ns1");
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", serviceName).formParam("version", "any").formParam("type", "Api")
-                .formParam("endpoint", "host:2222").when().post("/services").then().statusCode(201);
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", serviceName)
+                .formParam("version", "any").formParam("type", "Api").formParam("endpoint", "host:2222").when()
+                .post("/services").then().statusCode(201);
         Service service = given().contentType(MediaType.APPLICATION_JSON).get("/services/name/" + serviceName).then()
                 .statusCode(200).extract().as(Service.class);
         assertTrue(service.available);
@@ -94,10 +94,9 @@ public class ServiceDiscoveryJobTest {
         pauseScheduler();
         Service service = createService("ServiceDiscoveryJobTest3", "Api", "any", "host:3333");
         configureMockServiceFor("dummy-cluster-3", "host", "3333", "ns1");
-        given().header("HX-Request", true).contentType(MediaType.MULTIPART_FORM_DATA)
-                .multiPart("name", "dummy-cluster-3").multiPart("environment", "TEST")
-                .multiPart("excludedNamespaces", "kube-system,ingress").multiPart("url", "master:port").when()
-                .post("/clusters").then().statusCode(201);
+        given().contentType(MediaType.MULTIPART_FORM_DATA).multiPart("name", "dummy-cluster-3")
+                .multiPart("environment", "TEST").multiPart("excludedNamespaces", "kube-system,ingress")
+                .multiPart("url", "master:port").when().post("/clusters").then().statusCode(201);
         service = given().contentType(MediaType.APPLICATION_JSON).get("/services/name/" + service.name).then()
                 .statusCode(200).extract().as(Service.class);
         assertTrue(service.available);

--- a/app/src/test/java/io/halkyon/ServicesEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ServicesEndpointTest.java
@@ -30,12 +30,10 @@ public class ServicesEndpointTest {
 
     @Test
     public void serviceIsFoundByName() {
-        // An htmx request will contain a HX-Request header and Content-Type: application/x-www-form-urlencoded
-
         String rabbitMQ4 = "RabbitMQ4";
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", rabbitMQ4).formParam("version", "3.11.2").formParam("type", "Broker")
-                .formParam("endpoint", "tcp:5672").when().post("/services").then().statusCode(201);
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", rabbitMQ4)
+                .formParam("version", "3.11.2").formParam("type", "Broker").formParam("endpoint", "tcp:5672").when()
+                .post("/services").then().statusCode(201);
 
         Service service = given().contentType(MediaType.APPLICATION_JSON).get("/services/name/" + rabbitMQ4).then()
                 .statusCode(200).extract().as(Service.class);
@@ -50,8 +48,8 @@ public class ServicesEndpointTest {
         String prefix = "ServicesEndpointTest-testCannotAddServiceWithSameNameAndVersion-";
         Service service = createService(prefix + "service", "1", "type");
 
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", service.name).formParam("version", service.version).formParam("type", service.type)
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", service.name)
+                .formParam("version", service.version).formParam("type", service.type)
                 .formParam("endpoint", service.endpoint).when().post("/services").then().statusCode(409);
     }
 
@@ -61,8 +59,8 @@ public class ServicesEndpointTest {
         Service service1 = createService(prefix + "service", "1", "type");
         Service service2 = createService(prefix + "service", "2", "type");
 
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", service2.name).formParam("version", "1") // conflicts with version of service1!
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", service2.name)
+                .formParam("version", "1") // conflicts with version of service1!
                 .formParam("type", service2.type).formParam("endpoint", service2.endpoint).when()
                 .put("/services/" + service2.id).then().statusCode(409);
     }
@@ -112,10 +110,9 @@ public class ServicesEndpointTest {
     public void createStandaloneService() {
         String prefix = "ServicesEndpointTest-createStandaloneService-";
         String serviceName = prefix + "service";
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", serviceName).formParam("version", "3.11.2").formParam("type", "Broker")
-                .formParam("endpoint", "tcp:5672").formParam("externalEndpoint", "rabbit.com").when().post("/services")
-                .then().statusCode(201);
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", serviceName)
+                .formParam("version", "3.11.2").formParam("type", "Broker").formParam("endpoint", "tcp:5672")
+                .formParam("externalEndpoint", "rabbit.com").when().post("/services").then().statusCode(201);
 
         Service service = given().contentType(MediaType.APPLICATION_JSON).get("/services/name/" + serviceName).then()
                 .statusCode(200).extract().as(Service.class);

--- a/app/src/test/java/io/halkyon/utils/TestUtils.java
+++ b/app/src/test/java/io/halkyon/utils/TestUtils.java
@@ -32,7 +32,7 @@ public final class TestUtils {
     }
 
     public static Cluster createCluster(String clusterName, String url) {
-        given().header("HX-Request", true).contentType(MediaType.MULTIPART_FORM_DATA).multiPart("name", clusterName)
+        given().contentType(MediaType.MULTIPART_FORM_DATA).multiPart("name", clusterName)
                 .multiPart("environment", "PROD").multiPart("excludedNamespaces", "kube-system,ingress")
                 .multiPart("url", url).when().post("/clusters").then().statusCode(201);
 
@@ -53,19 +53,18 @@ public final class TestUtils {
 
     public static Service createService(String serviceName, String serviceVersion, String serviceType,
             String endpoint) {
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", serviceName).formParam("version", serviceVersion).formParam("type", serviceType)
-                .formParam("endpoint", endpoint).when().post("/services").then().statusCode(201);
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", serviceName)
+                .formParam("version", serviceVersion).formParam("type", serviceType).formParam("endpoint", endpoint)
+                .when().post("/services").then().statusCode(201);
 
-        Service service = given().contentType(MediaType.APPLICATION_JSON)
+        return given().contentType(MediaType.APPLICATION_JSON)
                 .get("/services/name/" + serviceName + "/version/" + serviceVersion).then().statusCode(200).extract()
                 .as(Service.class);
-        return service;
     }
 
     public static Claim createClaim(String claimName, String serviceRequested) {
-        given().header("HX-Request", true).contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .formParam("name", claimName).formParam("serviceRequested", serviceRequested).formParam("status", "new")
+        given().contentType(MediaType.APPLICATION_FORM_URLENCODED).formParam("name", claimName)
+                .formParam("serviceRequested", serviceRequested).formParam("status", "new")
                 .formParam("applicationId", "1").formParam("description", "claim for testing purposes").when()
                 .post("/claims").then().statusCode(201);
         return given().contentType(MediaType.APPLICATION_JSON).get("/claims/name/" + claimName).then().statusCode(200)

--- a/scripts/primaza.sh
+++ b/scripts/primaza.sh
@@ -107,7 +107,7 @@ function deploy() {
     pe "kind get kubeconfig -n ${CONTEXT_TO_USE} > local-kind-kubeconfig"
     pe "k cp local-kind-kubeconfig ${NAMESPACE}/${POD_NAME:4}:/tmp/local-kind-kubeconfig -c primaza-app"
 
-    RESULT=$(k exec -i $POD_NAME -c primaza-app -n ${NAMESPACE} -- sh -c "curl -X POST -H 'Content-Type: multipart/form-data' -H 'HX-Request: true' -F name=local-kind -F excludedNamespaces=$NS_TO_BE_EXCLUDED -F environment=DEV -F url=$KIND_URL -F kubeConfig=@/tmp/local-kind-kubeconfig -s -i localhost:8080/clusters")
+    RESULT=$(k exec -i $POD_NAME -c primaza-app -n ${NAMESPACE} -- sh -c "curl -X POST -H 'Content-Type: multipart/form-data' -F name=local-kind -F excludedNamespaces=$NS_TO_BE_EXCLUDED -F environment=DEV -F url=$KIND_URL -F kubeConfig=@/tmp/local-kind-kubeconfig -s -i localhost:8080/clusters")
     if [ "$RESULT" = *"500 Internal Server Error"* ]
     then
         p "Cluster failed to be saved in Primaza: $RESULT"
@@ -150,7 +150,7 @@ function localDeploy() {
     pe "kind get kubeconfig -n ${CONTEXT_TO_USE} > local-kind-kubeconfig"
     pe "k cp local-kind-kubeconfig ${NAMESPACE}/${POD_NAME:4}:/tmp/local-kind-kubeconfig -c primaza-app"
 
-    RESULT=$(k exec -i $POD_NAME -c primaza-app -n ${NAMESPACE} -- sh -c "curl -X POST -H 'Content-Type: multipart/form-data' -H 'HX-Request: true' -F name=local-kind -F excludedNamespaces=$NS_TO_BE_EXCLUDED -F environment=DEV -F url=$KIND_URL -F kubeConfig=@/tmp/local-kind-kubeconfig -s -i localhost:8080/clusters")
+    RESULT=$(k exec -i $POD_NAME -c primaza-app -n ${NAMESPACE} -- sh -c "curl -X POST -H 'Content-Type: multipart/form-data' -F name=local-kind -F excludedNamespaces=$NS_TO_BE_EXCLUDED -F environment=DEV -F url=$KIND_URL -F kubeConfig=@/tmp/local-kind-kubeconfig -s -i localhost:8080/clusters")
     if [ "$RESULT" = *"500 Internal Server Error"* ]
     then
         p "Cluster failed to be saved in Primaza: $RESULT"


### PR DESCRIPTION
This header was never used in the API, so let's remove it altogether.