### PR TITLE
Upgrade to Quarkus 3.1.0 and ensure scheduled tasks are not executed after app shutdown

### DIFF
--- a/app/src/main/java/io/halkyon/resource/page/ServiceResource.java
+++ b/app/src/main/java/io/halkyon/resource/page/ServiceResource.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
-import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -68,9 +67,7 @@ public class ServiceResource {
             response.withErrors(errors);
         } else {
             if (Service.count("name=?1 AND version=?2", request.name, request.version) > 0) {
-                throw new ClientErrorException(
-                        "Service name" + request.name + " and version " + request.version + " already exists",
-                        Response.Status.CONFLICT);
+                return responseServiceConflict(request);
             }
             Service service = new Service();
             doUpdateService(service, request);
@@ -111,7 +108,7 @@ public class ServiceResource {
             response.withErrors(errors);
         } else {
             if (Service.count("id != ?1 AND name=?2 AND version=?3", id, request.name, request.version) > 0) {
-                throw new ClientErrorException("Service name and version already exists", Response.Status.CONFLICT);
+                return responseServiceConflict(request);
             }
 
             doUpdateService(service, request);
@@ -233,5 +230,10 @@ public class ServiceResource {
         }
 
         service.persist();
+    }
+
+    private Response responseServiceConflict(@Form ServiceRequest request) {
+        return Response.status(Response.Status.CONFLICT)
+                .entity("Service name" + request.name + " and version " + request.version + " already exists").build();
     }
 }

--- a/app/src/main/java/io/halkyon/services/ApplicationDiscoveryJob.java
+++ b/app/src/main/java/io/halkyon/services/ApplicationDiscoveryJob.java
@@ -30,7 +30,7 @@ public class ApplicationDiscoveryJob {
     KubernetesClientService kubernetesClientService;
 
     @Transactional
-    @Scheduled(every = "${primaza.discovery-application-job.poll-every:5s}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(every = "${primaza.discovery-application-job.poll-every:5s}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP, skipExecutionIf = Scheduled.ApplicationNotRunning.class)
     public void execute() {
         List<Cluster> clusters = Cluster.listAll();
         for (Cluster cluster : clusters) {

--- a/app/src/main/java/io/halkyon/services/ClaimService.java
+++ b/app/src/main/java/io/halkyon/services/ClaimService.java
@@ -55,7 +55,7 @@ public class ClaimService {
      * pending claims and try to link the service if the criteria matches.
      */
     @Transactional
-    @Scheduled(every = "${primaza.update-claim-job.poll-every}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(every = "${primaza.update-claim-job.poll-every}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP, skipExecutionIf = Scheduled.ApplicationNotRunning.class)
     public void execute() {
         Claim.find("status in :statuses",
                 Collections.singletonMap("statuses",

--- a/app/src/main/java/io/halkyon/services/ServiceDiscoveryJob.java
+++ b/app/src/main/java/io/halkyon/services/ServiceDiscoveryJob.java
@@ -34,7 +34,7 @@ public class ServiceDiscoveryJob {
      * resource.
      */
     @Transactional
-    @Scheduled(every = "${primaza.discovery-service-job.poll-every}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(every = "${primaza.discovery-service-job.poll-every}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP, skipExecutionIf = Scheduled.ApplicationNotRunning.class)
     public void execute() {
         List<Service> services = Service.listAll();
         for (Service service : services) {
@@ -73,7 +73,7 @@ public class ServiceDiscoveryJob {
                 LOG.debugf("Checking after the service: %s, %s, %s", service.name, service.getProtocol(),
                         service.getPort());
                 if (updateServiceIfFoundInCluster(service, cluster)) {
-                    LOG.infof("Service: %s, %s found within namespace: %s of the cluster: %s", service.name,
+                    LOG.debugf("Service: %s, %s found within namespace: %s of the cluster: %s", service.name,
                             service.getPort(), service.namespace, service.cluster.name);
                     updated = true;
                     break;

--- a/app/src/test/java/io/halkyon/BaseTest.java
+++ b/app/src/test/java/io/halkyon/BaseTest.java
@@ -1,0 +1,102 @@
+package io.halkyon;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.mockito.Mockito;
+
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.halkyon.exceptions.ClusterConnectException;
+import io.halkyon.model.Cluster;
+import io.halkyon.services.KubernetesClientService;
+import io.halkyon.utils.ApplicationNameMatcher;
+import io.halkyon.utils.ClusterNameMatcher;
+import io.halkyon.utils.WebPageExtension;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+@QuarkusTestResource(WebPageExtension.class)
+public abstract class BaseTest {
+
+    WebPageExtension.PageManager page;
+
+    @InjectMock
+    KubernetesClientService mockKubernetesClientService;
+
+    @Inject
+    Scheduler scheduler;
+
+    protected void configureMockApplicationWithEmptyFor(Cluster cluster) {
+        try {
+            Mockito.when(
+                    mockKubernetesClientService.getDeploymentsInCluster(argThat(new ClusterNameMatcher(cluster.name))))
+                    .thenReturn(Collections.emptyList());
+        } catch (ClusterConnectException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void configureMockApplicationFor(String clusterName, String appName, String appImage,
+            String appNamespace) {
+        try {
+            Mockito.when(
+                    mockKubernetesClientService.getDeploymentsInCluster(argThat(new ClusterNameMatcher(clusterName))))
+                    .thenReturn(Arrays.asList(
+                            new DeploymentBuilder().withNewMetadata().withName(appName).withNamespace(appNamespace)
+                                    .endMetadata().withNewSpec().withNewTemplate().withNewSpec().addNewContainer()
+                                    .withImage(appImage).endContainer().endSpec().endTemplate().endSpec().build()));
+            Mockito.when(mockKubernetesClientService.getIngressHost(argThat(new ApplicationNameMatcher(appName))))
+                    .thenReturn("");
+        } catch (ClusterConnectException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void configureMockApplicationIngressFor(String appName, String appIngress) {
+        try {
+            Mockito.when(mockKubernetesClientService.getIngressHost(argThat(new ApplicationNameMatcher(appName))))
+                    .thenReturn(appIngress);
+        } catch (ClusterConnectException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void configureMockServiceFor(String clusterName, String protocol, String servicePort,
+            String serviceNamespace) {
+        configureMockServiceFor(clusterName, protocol, servicePort,
+                new ServiceBuilder().withNewMetadata().withNamespace(serviceNamespace).endMetadata());
+    }
+
+    protected void configureMockServiceWithIngressFor(String clusterName, String protocol, String servicePort,
+            String serviceNamespace, String serviceExternalIp) {
+        configureMockServiceFor(clusterName, protocol, servicePort,
+                new ServiceBuilder().withNewMetadata().withNamespace(serviceNamespace).endMetadata().withNewStatus()
+                        .withNewLoadBalancer().addNewIngress().withIp(serviceExternalIp).endIngress().endLoadBalancer()
+                        .endStatus());
+    }
+
+    protected void configureMockServiceFor(String clusterName, String protocol, String servicePort,
+            ServiceBuilder serviceBuilder) {
+        try {
+            Mockito.when(mockKubernetesClientService.getServiceInCluster(argThat(new ClusterNameMatcher(clusterName)),
+                    eq(protocol), eq(servicePort))).thenReturn(Optional.of(serviceBuilder.build()));
+        } catch (ClusterConnectException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void pauseScheduler() {
+        scheduler.pause();
+        await().atMost(30, SECONDS).until(() -> !scheduler.isRunning());
+    }
+}

--- a/app/src/test/java/io/halkyon/ClaimsEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ClaimsEndpointTest.java
@@ -13,8 +13,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import io.halkyon.model.Claim;
-import io.halkyon.utils.WebPageExtension;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
@@ -22,10 +20,7 @@ import io.restassured.response.ResponseBody;
 import io.restassured.specification.RequestSpecification;
 
 @QuarkusTest
-@QuarkusTestResource(WebPageExtension.class)
-public class ClaimsEndpointTest {
-
-    WebPageExtension.PageManager page;
+public class ClaimsEndpointTest extends BaseTest {
 
     @Test
     public void testQueryClaimBody() {

--- a/app/src/test/java/io/halkyon/ClustersEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ClustersEndpointTest.java
@@ -10,23 +10,12 @@ import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
 
 import io.halkyon.model.Cluster;
-import io.halkyon.services.KubernetesClientService;
-import io.halkyon.utils.WebPageExtension;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 
 @QuarkusTest
-@QuarkusTestResource(WebPageExtension.class)
-public class ClustersEndpointTest {
-
-    WebPageExtension.PageManager page;
-
-    @InjectMock
-    KubernetesClientService mockKubernetesClientService;
+public class ClustersEndpointTest extends BaseTest {
 
     @Test
-    // @Disabled
     public void testAddClusterViaHtmxForm() {
         given().contentType(MediaType.MULTIPART_FORM_DATA).multiPart("name", "ocp4.11-node-2")
                 .multiPart("environment", "TEST").multiPart("excludedNamespaces", "kube-system,ingress")

--- a/app/src/test/java/io/halkyon/CredentialsPageTest.java
+++ b/app/src/test/java/io/halkyon/CredentialsPageTest.java
@@ -9,15 +9,10 @@ import org.junit.jupiter.api.Test;
 
 import io.halkyon.model.Credential;
 import io.halkyon.model.Service;
-import io.halkyon.utils.WebPageExtension;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(WebPageExtension.class)
-public class CredentialsPageTest {
-
-    WebPageExtension.PageManager page;
+public class CredentialsPageTest extends BaseTest {
 
     @Test
     public void testCreateNewCredential() {

--- a/app/src/test/java/io/halkyon/HomeResourceTest.java
+++ b/app/src/test/java/io/halkyon/HomeResourceTest.java
@@ -2,15 +2,10 @@ package io.halkyon;
 
 import org.junit.jupiter.api.Test;
 
-import io.halkyon.utils.WebPageExtension;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(WebPageExtension.class)
-public class HomeResourceTest {
-
-    WebPageExtension.PageManager page;
+public class HomeResourceTest extends BaseTest {
 
     @Test
     public void testShouldRedirectToHome() {

--- a/app/src/test/java/io/halkyon/ServiceDiscoveryJobTest.java
+++ b/app/src/test/java/io/halkyon/ServiceDiscoveryJobTest.java
@@ -2,10 +2,7 @@ package io.halkyon;
 
 import static io.halkyon.utils.TestUtils.createCluster;
 import static io.halkyon.utils.TestUtils.createService;
-import static io.halkyon.utils.TestUtils.mockServiceIsAvailableInCluster;
 import static io.restassured.RestAssured.given;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -18,28 +15,14 @@ import org.junit.jupiter.api.Test;
 
 import io.halkyon.model.Cluster;
 import io.halkyon.model.Service;
-import io.halkyon.services.KubernetesClientService;
 import io.halkyon.services.ServiceDiscoveryJob;
-import io.halkyon.utils.WebPageExtension;
-import io.quarkus.scheduler.Scheduler;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 
 @QuarkusTest
-@QuarkusTestResource(WebPageExtension.class)
-public class ServiceDiscoveryJobTest {
-
-    @InjectMock
-    KubernetesClientService mockKubernetesClientService;
+public class ServiceDiscoveryJobTest extends BaseTest {
 
     @Inject
     ServiceDiscoveryJob job;
-
-    @Inject
-    Scheduler scheduler;
-
-    WebPageExtension.PageManager page;
 
     @Test
     public void testJobShouldMarkClaimAsErrorAfterMaxAttemptsExceeded() {
@@ -67,8 +50,6 @@ public class ServiceDiscoveryJobTest {
         assertTrue(service.available);
         assertNotNull(service.cluster);
         assertEquals(cluster.name, service.cluster.name);
-        // TODO this should be asserted in a the KuberentesClientServiceTest
-        // thenServiceIsInTheAvailableServicePage(service);
     }
 
     @Test
@@ -85,8 +66,6 @@ public class ServiceDiscoveryJobTest {
         assertTrue(service.available);
         assertNotNull(service.cluster);
         assertEquals(cluster.name, service.cluster.name);
-        // TODO this should be asserted in a the KuberentesClientServiceTest
-        // thenServiceIsInTheAvailableServicePage(service);
     }
 
     @Test
@@ -102,25 +81,5 @@ public class ServiceDiscoveryJobTest {
         assertTrue(service.available);
         assertNotNull(service.cluster);
         assertEquals("dummy-cluster-3", service.cluster.name);
-        // TODO this should be asserted in a the KuberentesClientServiceTest
-        // thenServiceIsInTheAvailableServicePage(service);
-    }
-
-    private void thenServiceIsInTheAvailableServicePage(Service expectedService) {
-        page.goTo("/services/discovered");
-        page.assertContentContains(expectedService.name);
-        page.assertContentContains(expectedService.getProtocol() + "://" + expectedService.name + "."
-                + expectedService.namespace + ":" + expectedService.getPort());
-    }
-
-    private void configureMockServiceFor(String clusterName, String protocol, String servicePort,
-            String serviceNamespace) {
-        mockServiceIsAvailableInCluster(mockKubernetesClientService, clusterName, protocol, servicePort,
-                serviceNamespace);
-    }
-
-    private void pauseScheduler() {
-        scheduler.pause();
-        await().atMost(30, SECONDS).until(() -> !scheduler.isRunning());
     }
 }

--- a/app/src/test/java/io/halkyon/ServicesEndpointTest.java
+++ b/app/src/test/java/io/halkyon/ServicesEndpointTest.java
@@ -13,20 +13,10 @@ import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
 
 import io.halkyon.model.Service;
-import io.halkyon.services.KubernetesClientService;
-import io.halkyon.utils.WebPageExtension;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 
 @QuarkusTest
-@QuarkusTestResource(WebPageExtension.class)
-public class ServicesEndpointTest {
-
-    WebPageExtension.PageManager page;
-
-    @InjectMock
-    KubernetesClientService mockKubernetesClientService;
+public class ServicesEndpointTest extends BaseTest {
 
     @Test
     public void serviceIsFoundByName() {

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.1.0.Final</quarkus.platform.version>
         <htmlunit.version>2.66.0</htmlunit.version>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <formatter-maven-plugin.version>2.21.0</formatter-maven-plugin.version>


### PR DESCRIPTION
- [Create BaseTest to always mock the k8s client](https://github.com/halkyonio/primaza-poc/commit/dc4ce0903e88fb88b545eca0b49135e92cd8fa82)
- [Upgrade to Quarkus 3.1.0.Final which fixes an issue with fabric8 client](https://github.com/halkyonio/primaza-poc/commit/d88963cc34b7df5bd60df8861b672d0c64780c38)
- [Ensure scheduled tasks are not run after application shutdown](https://github.com/halkyonio/primaza-poc/commit/e377245c26edf891922866ee5b21673ef3218566)